### PR TITLE
feat: add 'video' param for iOS

### DIFF
--- a/CapgoCapacitorStreamCall.podspec
+++ b/CapgoCapacitorStreamCall.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '14.0'
   s.dependency 'Capacitor'
-  s.dependency 'StreamVideo', '1.20.0'
-  s.dependency 'StreamVideoSwiftUI', '1.20.0'
+  s.dependency 'StreamVideo'
+  s.dependency 'StreamVideoSwiftUI'
   s.swift_version = '5.1'
 end

--- a/README.md
+++ b/README.md
@@ -341,12 +341,13 @@ Get the current call status
 
 #### CallOptions
 
-| Prop          | Type                                          | Description                                      |
-| ------------- | --------------------------------------------- | ------------------------------------------------ |
-| **`userIds`** | <code>string[]</code>                         | User ID of the person to call                    |
-| **`type`**    | <code><a href="#calltype">CallType</a></code> | Type of call, defaults to 'default'              |
-| **`ring`**    | <code>boolean</code>                          | Whether to ring the other user, defaults to true |
-| **`team`**    | <code>string</code>                           | Team name to call                                |
+| Prop          | Type                                          | Description                                                                                                                                                                         |
+| ------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`userIds`** | <code>string[]</code>                         | User ID of the person to call                                                                                                                                                       |
+| **`type`**    | <code><a href="#calltype">CallType</a></code> | Type of call, defaults to 'default'                                                                                                                                                 |
+| **`ring`**    | <code>boolean</code>                          | Whether to ring the other user, defaults to true                                                                                                                                    |
+| **`team`**    | <code>string</code>                           | Team name to call                                                                                                                                                                   |
+| **`video`**   | <code>boolean</code>                          | Whether to use the 'video' call type. This will change the call type within CallKit iOS, but it will not change the call type within Android. !!! This is not supported on Android. |
 
 
 #### CallEvent

--- a/example-app/ios/App/Podfile
+++ b/example-app/ios/App/Podfile
@@ -8,6 +8,10 @@ use_frameworks!
 # Requires CocoaPods 1.6 or newer
 install! 'cocoapods', :disable_input_output_paths => true
 
+# Use the develop branch for StreamVideo SDK
+pod 'StreamVideo', :git => 'https://github.com/GetStream/stream-video-swift.git', :branch => 'develop'
+pod 'StreamVideoSwiftUI', :git => 'https://github.com/GetStream/stream-video-swift.git', :branch => 'develop'
+
 def capacitor_pods
   pod 'Capacitor', :path => '../../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../../node_modules/@capacitor/ios'

--- a/example-app/src/app/tab1/tab1.page.ts
+++ b/example-app/src/app/tab1/tab1.page.ts
@@ -105,7 +105,8 @@ export class Tab1Page {
       await StreamCall.call({
         userIds: userIds,
         type: 'default',
-        ring: true
+        ring: true,
+        video: true
       });
       await this.presentToast(`Calling ${userIds}...`, 'success');
     } catch (error) {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,8 +5,8 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'StreamVideo', :git => 'https://github.com/GetStream/stream-video-swift.git', :tag => '1.16.0'
-  pod 'StreamVideoSwiftUI', :git => 'https://github.com/GetStream/stream-video-swift.git', :tag => '1.16.0'
+  pod 'StreamVideo', :git => 'https://github.com/GetStream/stream-video-swift.git', :branch => 'develop'
+  pod 'StreamVideoSwiftUI', :git => 'https://github.com/GetStream/stream-video-swift.git', :branch => 'develop'
 end
 
 target 'Plugin' do

--- a/ios/Sources/StreamCallPlugin/StreamCallPlugin.swift
+++ b/ios/Sources/StreamCallPlugin/StreamCallPlugin.swift
@@ -52,6 +52,7 @@ public class StreamCallPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @Injected(\.callKitAdapter) var callKitAdapter
     @Injected(\.callKitPushNotificationAdapter) var callKitPushNotificationAdapter
+    @Injected(\.callKitService) var callKitService
     private var webviewDelegate: WebviewNavigationDelegate?
 
     // Declare as optional and initialize in load() method
@@ -394,6 +395,7 @@ public class StreamCallPlugin: CAPPlugin, CAPBridgedPlugin {
             let callType = call.getString("type") ?? "default"
             let shouldRing = call.getBool("ring") ?? true
             let team = call.getString("team")
+            let video = call.getBool("video") ?? false
 
             // Generate a unique call ID
             let callId = UUID().uuidString
@@ -406,17 +408,19 @@ public class StreamCallPlugin: CAPPlugin, CAPBridgedPlugin {
                     print("- Users: \(members)")
                     print("- Should Ring: \(shouldRing)")
                     print("- Team: \(team)")
+                    print("- Video: \(video)")
 
 
 
                     // Update the CallOverlayView with the active call
                     // Create the call object
-                    await self.callViewModel?.startCall(
-                        callType: callType,
-                        callId: callId,
-                        members: members.map { Member(userId: $0, role: nil, customData: [:], updatedAt: nil) },
-                        ring: shouldRing
-                    )
+await self.callViewModel?.startCall(
+    callType: callType,
+    callId: callId,
+    members: members.map { Member(userId: $0, role: nil, customData: [:], updatedAt: nil) },
+    ring: shouldRing,
+    video: video
+)
                     
                     
                     // Update UI on main thread
@@ -641,6 +645,7 @@ public class StreamCallPlugin: CAPPlugin, CAPBridgedPlugin {
 
         // Register for incoming calls
         callKitAdapter.registerForIncomingCalls()
+        callKitService.supportsVideo = true
     }
 
     private func setupViews() {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -105,6 +105,8 @@ export interface CallOptions {
   ring?: boolean;
   /** Team name to call */
   team?: string;
+  /** Whether to use the 'video' call type. This will change the call type within CallKit iOS, but it will not change the call type within Android. !!! This is not supported on Android. */
+  video?: boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for initiating video calls on iOS devices.
  - Introduced a new optional "video" property in call options to enable video call functionality (iOS only).

- **Documentation**
  - Updated documentation to describe the new "video" property in call options and its platform-specific behavior.

- **Chores**
  - Updated iOS and example app dependencies to use the latest development versions of StreamVideo libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->