### PR TITLE
iOS - Add ability to provide a custom PushNotificationConfig

### DIFF
--- a/ios/Sources/StreamCallPlugin/StreamCallPlugin.swift
+++ b/ios/Sources/StreamCallPlugin/StreamCallPlugin.swift
@@ -48,6 +48,8 @@ public class StreamCallPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private var streamVideo: StreamVideo?
 
+    private var pushNotificationsConfig: PushNotificationsConfig?
+
     // Store current call info for getCallStatus
     private var currentCallId: String = ""
     private var currentCallState: String = ""
@@ -354,6 +356,14 @@ public class StreamCallPlugin: CAPPlugin, CAPBridgedPlugin {
             imageURL: imageURL.flatMap { URL(string: $0) },
             customData: [:]
         )
+
+        // Get push notifications config if provided
+        if let pushConfig = call.getObject("pushNotificationsConfig") {
+            self.pushNotificationsConfig = PushNotificationsConfig(
+                pushProviderName: pushConfig["pushProviderName"] as? String ?? "",
+                voipProviderName: pushConfig["voipProviderName"] as? String ?? ""
+            )
+        }
 
         let credentials = UserCredentials(user: user, tokenValue: token)
         SecureUserRepository.shared.save(user: credentials)
@@ -773,6 +783,7 @@ public class StreamCallPlugin: CAPPlugin, CAPBridgedPlugin {
             apiKey: apiKey,
             user: savedCredentials.user,
             token: UserToken(stringLiteral: savedCredentials.tokenValue),
+            pushNotificationsConfig: self.pushNotificationsConfig,
             tokenProvider: {completion in
                 guard let savedCredentials = SecureUserRepository.shared.loadCurrentUser() else {
                     print("No saved credentials or API key found, cannot refresh token")

--- a/ios/Sources/StreamCallPlugin/StreamCallPlugin.swift
+++ b/ios/Sources/StreamCallPlugin/StreamCallPlugin.swift
@@ -359,9 +359,12 @@ public class StreamCallPlugin: CAPPlugin, CAPBridgedPlugin {
 
         // Get push notifications config if provided
         if let pushConfig = call.getObject("pushNotificationsConfig") {
+            let pushProviderName = pushConfig["pushProviderName"] as? String ?? "ios-apn"
+            let voipProviderName = pushConfig["voipProviderName"] as? String ?? "ios-voip"
+            
             self.pushNotificationsConfig = PushNotificationsConfig(
-                pushProviderName: pushConfig["pushProviderName"] as? String ?? "",
-                voipProviderName: pushConfig["voipProviderName"] as? String ?? ""
+                pushProviderInfo: PushProviderInfo(name: pushProviderName, pushProvider: .apn),
+                voipPushProviderInfo: PushProviderInfo(name: voipProviderName, pushProvider: .apn)
             )
         }
 
@@ -783,7 +786,7 @@ public class StreamCallPlugin: CAPPlugin, CAPBridgedPlugin {
             apiKey: apiKey,
             user: savedCredentials.user,
             token: UserToken(stringLiteral: savedCredentials.tokenValue),
-            pushNotificationsConfig: self.pushNotificationsConfig,
+            pushNotificationsConfig: self.pushNotificationsConfig ?? .default,
             tokenProvider: {completion in
                 guard let savedCredentials = SecureUserRepository.shared.loadCurrentUser() else {
                     print("No saved credentials or API key found, cannot refresh token")

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -21,6 +21,12 @@ export interface LoginOptions {
   apiKey: string;
   /** ID of the HTML element where the video will be rendered */
   magicDivId?: string;
+  pushNotificationsConfig?: PushNotificationsConfig;
+}
+
+export interface PushNotificationsConfig {
+  pushProviderName: string;
+  voipProviderName: string;
 }
 
 /**


### PR DESCRIPTION
- default push config for voip is using the voip config name `ios-voip` c.f. https://github.com/GetStream/stream-video-swift/blob/353dc72c4a64423b46df00e7536c52d2418cebf3/Sources/StreamVideo/Models/PushNotificationsConfig.swift#L23
- as we have several app with different app ids, we have different .p8 voip certificates uploaded to the getstream dashboard. This PR allows initializing the stream SDK with a voip configuration like this:

```
      await StreamCall.login({
        apiKey,
        token,
        userId,
        imageURL,
        name,
        pushNotificationsConfig: {
          pushProviderName: 'ios-apn-custom',
          voipProviderName: 'ios-voip-custom'
        }
```
- to stay consistant with the Stream interface, this PR also adds the `pushProviderName` in the interface in case it needs to be customized (not only the voip name)

This enables multiple iOS apps to receive calls within the same getstream project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring push notification providers during login.
  - Users can now specify push and VoIP provider names when logging in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->