### PR TITLE
Android - prevent ending a call as soon as user has joined a call 

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor/streamcall/StreamCallPlugin.kt
+++ b/android/src/main/java/ee/forgr/capacitor/streamcall/StreamCallPlugin.kt
@@ -52,7 +52,6 @@ import io.getstream.android.video.generated.models.CallMissedEvent
 import io.getstream.android.video.generated.models.CallRejectedEvent
 import io.getstream.android.video.generated.models.CallRingEvent
 import io.getstream.android.video.generated.models.CallSessionEndedEvent
-import io.getstream.android.video.generated.models.CallSessionParticipantCountsUpdatedEvent
 import io.getstream.android.video.generated.models.CallSessionParticipantLeftEvent
 import io.getstream.android.video.generated.models.CallSessionStartedEvent
 import io.getstream.android.video.generated.models.VideoEvent
@@ -824,7 +823,7 @@ public class StreamCallPlugin : Plugin() {
                         updateCallStatusAndNotify(event.callCid, "left")
                     }
 
-                    is ParticipantLeftEvent, is CallSessionParticipantLeftEvent, is CallSessionParticipantCountsUpdatedEvent -> {
+                    is ParticipantLeftEvent, is CallSessionParticipantLeftEvent -> {
                         val activeCall = streamVideoClient?.state?.activeCall?.value
 
                         val callId = when (event) {
@@ -832,9 +831,6 @@ public class StreamCallPlugin : Plugin() {
                                 event.callCid
                             }
                             is CallSessionParticipantLeftEvent -> {
-                                event.callCid
-                            }
-                            is CallSessionParticipantCountsUpdatedEvent -> {
                                 event.callCid
                             }
 


### PR DESCRIPTION
**Context** 
Call is ending automatically as soon as android joins the call and this is due to `CallSessionParticipantCountsUpdatedEvent` being `1` when joining at the beginning so it will trigger end call. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated event handling logic to no longer process participant count update events, focusing only on participant leave events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->