### PR TITLE
Android - Add vibrationConfig introduced in v1.14.0

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor/streamcall/StreamCallPlugin.kt
+++ b/android/src/main/java/ee/forgr/capacitor/streamcall/StreamCallPlugin.kt
@@ -79,6 +79,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import io.getstream.video.android.core.sounds.RingingConfig
 import io.getstream.video.android.core.sounds.toSounds
+import io.getstream.video.android.core.sounds.enableRingingCallVibrationConfig
 import io.getstream.video.android.model.Device
 import io.getstream.video.android.model.User
 import io.getstream.video.android.model.streamCallId
@@ -863,7 +864,8 @@ class StreamCallPlugin : Plugin() {
         token = savedCredentials.tokenValue,
         notificationConfig = notificationConfig,
         sounds = soundsConfig.toSounds(),
-        loggingLevel = LoggingLevel(priority = Priority.INFO)
+        loggingLevel = LoggingLevel(priority = Priority.INFO),
+        vibrationConfig = enableRingingCallVibrationConfig()
       ).build()
 
       // don't do event handler registration when activity may be null


### PR DESCRIPTION
- stream-video-android is already on 1.14.0. This SDK adds the possibility to vibrate during an incoming call https://github.com/GetStream/stream-video-android/releases/tag/1.14.0
- In this PR, we add the `vibrationConfig` in  `StreamVideoBuilder` to enable vibration depending on device settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vibration feedback for incoming calls on Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->