### PR TITLE
Fix ring muted on android 

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor/streamcall/StreamCallPlugin.kt
+++ b/android/src/main/java/ee/forgr/capacitor/streamcall/StreamCallPlugin.kt
@@ -174,7 +174,7 @@ class StreamCallPlugin : Plugin() {
     }
     
     val mutedConfig = object : MutedRingingConfig {
-      override val playIncomingSoundIfMuted: Boolean = true
+      override val playIncomingSoundIfMuted: Boolean = false
       override val playOutgoingSoundIfMuted: Boolean = true
     }
     


### PR DESCRIPTION
1. When android has Do not disturb mode turned on, the outgoing sound should still be playing + incoming sound should be muted to match IOS behaviour 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal sound configuration architecture in the Android plugin for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->